### PR TITLE
Minor updates to get cs tests to pass

### DIFF
--- a/cs-config/cs_config/helpers.py
+++ b/cs-config/cs_config/helpers.py
@@ -5,7 +5,7 @@
 // Date: March 2021
 // ===========================================================#
 '''
-{
+arp_ref = {
       "CDCC_c": {"2021": 0.0},
       "CDCC_new_c": {"2021": 8000.0},
       "CDCC_new_rt": {"2021": 0.5},
@@ -34,8 +34,8 @@
       "EITC_MaxEligAge": {"2021": 125},
       "EITC_InvestIncome_c": {"2021": 10000.0},
       "EITC_excess_InvestIncome_rt": {"2021": 9e+99},
-      "EITC_indiv": {"2021": false},
-      "EITC_sep_filers_elig": {"2021": false},
+      "EITC_indiv": {"2021": False},
+      "EITC_sep_filers_elig": {"2021": False},
 
       "Rebate_c": {"2021": 1400.0},
       "Rebate_ps": {"2021": [75000.0, 150000.0, 75000.0, 112500.0, 150000.0]},

--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,8 +1,5 @@
 # bash commands for installing your package
 
-git clone https://github.com/grantseiter/Tax-Cruncher-ARP
-cd Tax-Cruncher
-conda install PSLmodels::taxcalc PSLmodels::behresp "conda-forge::paramtools>=0.15.1" "bokeh<2.0.0"
 pip install -e .
 cd taxcalc_arp
 pip install -e .


### PR DESCRIPTION
@grantseiter Hope I'm not stepping on your toes. I checked the code out locally and only needed to make a couple minor modifications. With these minor changes, the cs tests pass.

![image](https://user-images.githubusercontent.com/9206065/111319811-c408c180-863c-11eb-82b8-2b64c02d058f.png)


If you want to run the tests locally, a good way to simulate the CS install process is to run these commands (sorry this should be in the Compute Studio publishing documentation):

```bash
# download repo
git clone git@github.com:grantseiter/Tax-Cruncher-ARP.git
cd Tax-Cruncher-ARP

# create a conda environment with pip and pytest to install packages into
conda create -n tc-arp-env pip pytest
conda activate tc-arp-env

# download cs-kit and pyyaml for installing more packages and running tests
pip install cs-kit pyyaml
csk build-env

# run any install commands that are in cs-config/install.sh
bash cs-config/install.sh

# create local installation of cs-config files
pip install -e ./cs-config

# run tests and fix errors as they arise
py.test cs-config -v -s
```
